### PR TITLE
修复获取所有文件时部分文件与实际文件相比缺少的问题

### DIFF
--- a/Everything 软件及源码资料/EverythingSZ 源码/EverythingSZ/Code/EverythingCSharp/USNJournalConsole/Program.cs
+++ b/Everything 软件及源码资料/EverythingSZ 源码/EverythingSZ/Code/EverythingCSharp/USNJournalConsole/Program.cs
@@ -16,14 +16,60 @@ namespace USNJournalConsole
 
             watch.Start();
 
-            var allFiles = Engine.GetAllFilesAndDirectories();
-
+            var allFiles = Engine.GetAllFilesAndDirectories("d");
             watch.Stop();
 
             Console.WriteLine("{0} files, {1} seconds", allFiles.Count(), watch.Elapsed.TotalSeconds);
-
+            watch.Restart();
+            var aaa = GetV(@"d:\");
+            watch.Stop();
+            File.WriteAllText(@"1.txt", string.Join(Environment.NewLine, aaa));
+            File.WriteAllText(@"2.txt", string.Join(Environment.NewLine, allFiles.Select(e=>e.FullFileName)));
+            Console.WriteLine("{0} files, {1} seconds", aaa.Count(), watch.Elapsed.TotalSeconds);
             Console.Write("Press any key to continue . . . ");
             Console.ReadKey(true);
         }
+
+        static IEnumerable<Entity> GetV(string path)
+        {
+            List<Entity> result = new List<Entity>();
+            if (!string.IsNullOrEmpty(path) && !path.Contains("System Volume Information") && !path.Contains("RECYCLE"))
+            {
+                var dirs = Directory.GetDirectories(path);
+                foreach (var item in dirs)
+                {
+                    var child = GetV(item);
+                    if (child != null)
+                        result.AddRange(child);
+                }
+                var files = Directory.GetFiles(path);
+                result.AddRange(files.Select(e => new Entity(e, false)));
+                result.AddRange(dirs.Select(e => new Entity(e, true)));
+                return result;
+            }
+            return null;
+        }
+
+        public class Entity
+        {
+            public override string ToString()
+            {
+                return Path;// + "," + (IsDir ? "1" : "0");
+            }
+            public Entity()
+            {
+
+            }
+            public Entity(string p, bool isd)
+            {
+                IsDir = isd;
+                Path = p;
+            }
+
+            public string Path { get; set; }
+
+            public bool IsDir { get; set; }
+        }
+
     }
 }

--- a/Everything 软件及源码资料/EverythingSZ 源码/EverythingSZ/Code/EverythingCSharp/UsnOperation/UsnOperator.cs
+++ b/Everything 软件及源码资料/EverythingSZ 源码/EverythingSZ/Code/EverythingCSharp/UsnOperation/UsnOperator.cs
@@ -101,7 +101,7 @@ namespace UsnOperation
             {
                 MFT_ENUM_DATA mftEnumData = new MFT_ENUM_DATA();
                 mftEnumData.StartFileReferenceNumber = 0;
-                mftEnumData.LowUsn = 21296;
+                mftEnumData.LowUsn = 0;//21296;
                 mftEnumData.HighUsn = this.ntfsUsnJournalData.NextUsn;
 
                 int sizeMftEnumData = Marshal.SizeOf(mftEnumData);
@@ -137,8 +137,8 @@ namespace UsnOperation
                     IntPtr ptrUsnRecord = new IntPtr(ptrData.ToInt32() + sizeof(Int64));
 
                     int count = 0;
-                    Console.WriteLine("outBytesCount: " + outBytesCount + "");
-                    Console.WriteLine("=======>>");////////
+                    //Console.WriteLine("outBytesCount: " + outBytesCount + "");
+                    //Console.WriteLine("=======>>");////////
                     UsnEntry ue = null;
                     while (outBytesCount > 60)
                     {
@@ -150,9 +150,9 @@ namespace UsnOperation
 
                         outBytesCount -= usnRecord.RecordLength;
 
-                        Console.WriteLine(count++ + "、" + ue.Usn + "\t" + usnRecord.FileName);////////
+                        //Console.WriteLine(count++ + "、" + ue.Usn + "\t" + usnRecord.FileName);////////
                     }
-                    Console.WriteLine(" =======<<");////////
+                    //Console.WriteLine(" =======<<");////////
 
                     Marshal.WriteInt64(ptrMftEnumData, Marshal.ReadInt64(ptrData, 0));
                 }


### PR DESCRIPTION
1. 修复excludeFolders 排除文件列表，导致的包含部分关键字的文件，也会被排除的问题
2. 去掉了死循环..
3. 修复不会显示磁盘根目录文件夹的问题
4. 修复驱动器列表中如果有CD驱动器存在时抛出异常的问题
5. 修复GetFolderPath函数，会导致有的文件夹没有路径而被排除
6. LowUsn 应该是0，原LowUsn 值GetEntries方法获取会缺少部分文件


